### PR TITLE
chore: add PR description template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+### Description
+
+#### What is changing?
+
+##### Is there new documentation needed for these changes?
+
+#### What is the motivation for this change?
+
+<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
+<!-- If this is a feature, it helps to describe the new use case enabled by this change -->
+
+<!--
+Contributors!
+First of all, thank you so much!!
+If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
+You can do that here: https://jira.mongodb.org/projects/NODE
+-->
+
+### Double check the following
+
+- [ ] Ran `npm run check:lint` script
+- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
+- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
+  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
+- [ ] Changes are covered by tests
+- [ ] New TODOs have a related JIRA ticket

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ You can do that here: https://jira.mongodb.org/projects/NODE
 
 ### Double check the following
 
-- [ ] Ran `npm run check:lint` script
+- [ ] Ran `npm run format:js && npm run format:rs` script
 - [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
 - [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
   - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
