### PR TITLE
fix(NODE-5177): update to latest zstd-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ napi = { version = "2.4.3", default-features = false, features = [
 ] }
 napi-derive = "2.4.1"
 zstd = "0.11"
+zstd-sys = "2.0.8"
 
 [build-dependencies]
 napi-build = "2.0.0"


### PR DESCRIPTION
### Description

Update to zstd-sys to get zstd 1.5.5 security fix.

#### What is changing?

Updates underlying dependency on zstd-sys.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5177

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run format:js && npm run format:rs` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
