### PR TITLE
docs(NODE-5528): add driver version compat table

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Zstandard compression library for Node.js
 npm install @mongodb-js/zstd
 ```
 
-## Support matrix
+## OS Support matrix
 
 |                  | node12 | node14 | node16 | node18 | node20 |
 | ---------------- | ------ | ------ | ------ | ------ | ------ |
@@ -22,6 +22,17 @@ npm install @mongodb-js/zstd
 | Linux arm64 gnu  | ✓      | ✓      | ✓      | ✓      | ✓      |
 | Linux x64 musl   | ✓      | ✓      | ✓      | ✓      | ✓      |
 | Linux arm64 musl | ✓      | ✓      | ✓      | ✓      | ✓      |
+
+## MongoDB Node.js Driver Version Compatibility
+
+Only the following version combinations with the [MongoDB Node.js Driver](https://github.com/mongodb/node-mongodb-native) are considered stable.
+
+|               | `@mongodb-js/zstd@1.x` |
+| ------------- | ---------------------- |
+| `mongodb@6.x` | ✓ _(^1.1.0)_           |
+| `mongodb@5.x` | ✓                      |
+| `mongodb@4.x` | ✓                      |
+| `mongodb@3.x` | N/A                    |
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Only the following version combinations with the [MongoDB Node.js Driver](https:
 
 |               | `@mongodb-js/zstd@1.x` |
 | ------------- | ---------------------- |
-| `mongodb@6.x` | ✓ _(^1.1.0)_           |
+| `mongodb@6.x` | ✓ `^1.1.0`           |
 | `mongodb@5.x` | ✓                      |
 | `mongodb@4.x` | ✓                      |
 | `mongodb@3.x` | N/A                    |


### PR DESCRIPTION
### Description
NODE-5528

#### What is changing?
Added table with version compat info for the nodejs driver

##### Is there new documentation needed for these changes?
This is documentation

#### What is the motivation for this change?
Clarity about add-on compatibility

### Double check the following

- [x] Ran `npm run format:js && npm run format:rs` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [N/A] Changes are covered by tests
- [N/A] New TODOs have a related JIRA ticket
