### PR TITLE
chore(NODE-6603): set errexit in install script and download prebuilt windows zstd

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-2019, macos-13]
-        # node: [16.20.1, 18.x, 20.x, 22.x]
-        node: [16.20.1]
+        node: [16.20.1, 18.x, 20.x, 22.x]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -37,80 +36,80 @@ jobs:
         shell: bash
         run: npm test
 
-  # container_tests_glibc:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       linux_arch: [s390x, arm64, amd64]
-  #       node: [16.x, 18.x, 20.x, 22.x]
-  #     fail-fast: false
-  #   steps:
-  #     - uses: actions/checkout@v4
+  container_tests_glibc:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        linux_arch: [s390x, arm64, amd64]
+        node: [16.x, 18.x, 20.x, 22.x]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ matrix.node }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
 
-  #     - name: Get Full Node.js Version
-  #       id: get_nodejs_version
-  #       shell: bash
-  #       run: |
-  #         echo "version=$(node --print 'process.version.slice(1)')" >> "$GITHUB_OUTPUT"
-  #         echo "ubuntu_version=$(node --print '(+process.version.slice(1).split(`.`).at(0)) > 16 ? `noble` : `bionic`')" >> "$GITHUB_OUTPUT"
+      - name: Get Full Node.js Version
+        id: get_nodejs_version
+        shell: bash
+        run: |
+          echo "version=$(node --print 'process.version.slice(1)')" >> "$GITHUB_OUTPUT"
+          echo "ubuntu_version=$(node --print '(+process.version.slice(1).split(`.`).at(0)) > 16 ? `noble` : `bionic`')" >> "$GITHUB_OUTPUT"
 
-  #     - name: Set up QEMU
-  #       uses: docker/setup-qemu-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-  #     - name: Run Buildx
-  #       run: |
-  #         docker buildx create --name builder --bootstrap --use
-  #         docker buildx build \
-  #           --platform linux/${{ matrix.linux_arch }} \
-  #           --build-arg="NODE_ARCH=${{ matrix.linux_arch == 'amd64' && 'x64' || matrix.linux_arch }}" \
-  #           --build-arg="NODE_VERSION=${{ steps.get_nodejs_version.outputs.version }}" \
-  #           --build-arg="UBUNTU_VERSION=${{ steps.get_nodejs_version.outputs.ubuntu_version }}" \
-  #           --build-arg="RUN_TEST=true" \
-  #           --output type=local,dest=./prebuilds,platform-split=false \
-  #           -f ./.github/docker/Dockerfile.glibc \
-  #           .
+      - name: Run Buildx
+        run: |
+          docker buildx create --name builder --bootstrap --use
+          docker buildx build \
+            --platform linux/${{ matrix.linux_arch }} \
+            --build-arg="NODE_ARCH=${{ matrix.linux_arch == 'amd64' && 'x64' || matrix.linux_arch }}" \
+            --build-arg="NODE_VERSION=${{ steps.get_nodejs_version.outputs.version }}" \
+            --build-arg="UBUNTU_VERSION=${{ steps.get_nodejs_version.outputs.ubuntu_version }}" \
+            --build-arg="RUN_TEST=true" \
+            --output type=local,dest=./prebuilds,platform-split=false \
+            -f ./.github/docker/Dockerfile.glibc \
+            .
 
-  # container_tests_musl:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       linux_arch: [amd64, arm64]
-  #       node: [16.20.1, 18.x, 20.x, 22.x]
-  #     fail-fast: false
-  #   steps:
-  #     - uses: actions/checkout@v4
+  container_tests_musl:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        linux_arch: [amd64, arm64]
+        node: [16.20.1, 18.x, 20.x, 22.x]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ matrix.node }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
 
-  #     - name: Get Full Node.js Version
-  #       id: get_nodejs_version
-  #       shell: bash
-  #       run: |
-  #         echo "version=$(node --print 'process.version.slice(1)')" >> "$GITHUB_OUTPUT"
+      - name: Get Full Node.js Version
+        id: get_nodejs_version
+        shell: bash
+        run: |
+          echo "version=$(node --print 'process.version.slice(1)')" >> "$GITHUB_OUTPUT"
 
-  #     - name: Set up QEMU
-  #       uses: docker/setup-qemu-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-  #     - name: Run Buildx
-  #       run: |
-  #         docker buildx create --name builder --bootstrap --use
-  #         docker --debug buildx build --progress=plain --no-cache \
-  #           --platform linux/${{ matrix.linux_arch }} \
-  #           --build-arg="PLATFORM=${{ matrix.linux_arch == 'arm64' && 'arm64v8' || matrix.linux_arch }}" \
-  #           --build-arg="NODE_VERSION=${{ steps.get_nodejs_version.outputs.version }}" \
-  #           --build-arg="RUN_TEST=true" \
-  #           --output type=local,dest=./prebuilds,platform-split=false \
-  #           -f ./.github/docker/Dockerfile.musl \
-  #           .
+      - name: Run Buildx
+        run: |
+          docker buildx create --name builder --bootstrap --use
+          docker --debug buildx build --progress=plain --no-cache \
+            --platform linux/${{ matrix.linux_arch }} \
+            --build-arg="PLATFORM=${{ matrix.linux_arch == 'arm64' && 'arm64v8' || matrix.linux_arch }}" \
+            --build-arg="NODE_VERSION=${{ steps.get_nodejs_version.outputs.version }}" \
+            --build-arg="RUN_TEST=true" \
+            --output type=local,dest=./prebuilds,platform-split=false \
+            -f ./.github/docker/Dockerfile.musl \
+            .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm run install-zstd
         shell: bash
 
-      - name: install dependencies and compmile
+      - name: install dependencies and compile
         run: npm install --loglevel verbose
         shell: bash
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,8 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-2019, macos-13]
-        node: [16.20.1, 18.x, 20.x, 22.x]
+        # node: [16.20.1, 18.x, 20.x, 22.x]
+        node: [16.20.1]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -36,80 +37,80 @@ jobs:
         shell: bash
         run: npm test
 
-  container_tests_glibc:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        linux_arch: [s390x, arm64, amd64]
-        node: [16.x, 18.x, 20.x, 22.x]
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v4
+  # container_tests_glibc:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       linux_arch: [s390x, arm64, amd64]
+  #       node: [16.x, 18.x, 20.x, 22.x]
+  #     fail-fast: false
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node }}
+  #     - uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ matrix.node }}
 
-      - name: Get Full Node.js Version
-        id: get_nodejs_version
-        shell: bash
-        run: |
-          echo "version=$(node --print 'process.version.slice(1)')" >> "$GITHUB_OUTPUT"
-          echo "ubuntu_version=$(node --print '(+process.version.slice(1).split(`.`).at(0)) > 16 ? `noble` : `bionic`')" >> "$GITHUB_OUTPUT"
+  #     - name: Get Full Node.js Version
+  #       id: get_nodejs_version
+  #       shell: bash
+  #       run: |
+  #         echo "version=$(node --print 'process.version.slice(1)')" >> "$GITHUB_OUTPUT"
+  #         echo "ubuntu_version=$(node --print '(+process.version.slice(1).split(`.`).at(0)) > 16 ? `noble` : `bionic`')" >> "$GITHUB_OUTPUT"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+  #     - name: Set up QEMU
+  #       uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v3
 
-      - name: Run Buildx
-        run: |
-          docker buildx create --name builder --bootstrap --use
-          docker buildx build \
-            --platform linux/${{ matrix.linux_arch }} \
-            --build-arg="NODE_ARCH=${{ matrix.linux_arch == 'amd64' && 'x64' || matrix.linux_arch }}" \
-            --build-arg="NODE_VERSION=${{ steps.get_nodejs_version.outputs.version }}" \
-            --build-arg="UBUNTU_VERSION=${{ steps.get_nodejs_version.outputs.ubuntu_version }}" \
-            --build-arg="RUN_TEST=true" \
-            --output type=local,dest=./prebuilds,platform-split=false \
-            -f ./.github/docker/Dockerfile.glibc \
-            .
+  #     - name: Run Buildx
+  #       run: |
+  #         docker buildx create --name builder --bootstrap --use
+  #         docker buildx build \
+  #           --platform linux/${{ matrix.linux_arch }} \
+  #           --build-arg="NODE_ARCH=${{ matrix.linux_arch == 'amd64' && 'x64' || matrix.linux_arch }}" \
+  #           --build-arg="NODE_VERSION=${{ steps.get_nodejs_version.outputs.version }}" \
+  #           --build-arg="UBUNTU_VERSION=${{ steps.get_nodejs_version.outputs.ubuntu_version }}" \
+  #           --build-arg="RUN_TEST=true" \
+  #           --output type=local,dest=./prebuilds,platform-split=false \
+  #           -f ./.github/docker/Dockerfile.glibc \
+  #           .
 
-  container_tests_musl:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        linux_arch: [amd64, arm64]
-        node: [16.20.1, 18.x, 20.x, 22.x]
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v4
+  # container_tests_musl:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       linux_arch: [amd64, arm64]
+  #       node: [16.20.1, 18.x, 20.x, 22.x]
+  #     fail-fast: false
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node }}
+  #     - uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ matrix.node }}
 
-      - name: Get Full Node.js Version
-        id: get_nodejs_version
-        shell: bash
-        run: |
-          echo "version=$(node --print 'process.version.slice(1)')" >> "$GITHUB_OUTPUT"
+  #     - name: Get Full Node.js Version
+  #       id: get_nodejs_version
+  #       shell: bash
+  #       run: |
+  #         echo "version=$(node --print 'process.version.slice(1)')" >> "$GITHUB_OUTPUT"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+  #     - name: Set up QEMU
+  #       uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v3
 
-      - name: Run Buildx
-        run: |
-          docker buildx create --name builder --bootstrap --use
-          docker --debug buildx build --progress=plain --no-cache \
-            --platform linux/${{ matrix.linux_arch }} \
-            --build-arg="PLATFORM=${{ matrix.linux_arch == 'arm64' && 'arm64v8' || matrix.linux_arch }}" \
-            --build-arg="NODE_VERSION=${{ steps.get_nodejs_version.outputs.version }}" \
-            --build-arg="RUN_TEST=true" \
-            --output type=local,dest=./prebuilds,platform-split=false \
-            -f ./.github/docker/Dockerfile.musl \
-            .
+  #     - name: Run Buildx
+  #       run: |
+  #         docker buildx create --name builder --bootstrap --use
+  #         docker --debug buildx build --progress=plain --no-cache \
+  #           --platform linux/${{ matrix.linux_arch }} \
+  #           --build-arg="PLATFORM=${{ matrix.linux_arch == 'arm64' && 'arm64v8' || matrix.linux_arch }}" \
+  #           --build-arg="NODE_VERSION=${{ steps.get_nodejs_version.outputs.version }}" \
+  #           --build-arg="RUN_TEST=true" \
+  #           --output type=local,dest=./prebuilds,platform-split=false \
+  #           -f ./.github/docker/Dockerfile.musl \
+  #           .

--- a/binding.gyp
+++ b/binding.gyp
@@ -23,9 +23,12 @@
           {
             'link_settings': {
               'libraries': [
-                '<(module_root_dir)/deps/zstd/build/cmake/lib/Debug/zstd_static.lib'
+                '<(module_root_dir)/deps/zstd/static/zstd_static.lib'
               ]
             },
+            'include_dirs': [
+              '<(module_root_dir)/deps/zstd/include'
+            ],
           },
           { # macos and linux
           'link_settings': {

--- a/etc/install-zstd.sh
+++ b/etc/install-zstd.sh
@@ -11,9 +11,12 @@ download_zstd() {
 	ZSTD_VERSION=$(node -p "require('./package.json')['mongodb:zstd_version']")
 	is_windows=$(node -p "process.platform === 'win32'")
 
-	if [ "$is_windows" == "true" ]; then
-		curl -L "https://github.com/facebook/zstd/releases/download/v$ZSTD_VERSION/zstd-$ZSTD_VERSION-win64.zip" \
-	 	| 	unzip - -C deps/zstd 
+	if [ "$is_windows" == "false" ]; then
+		curl -L -o zstd.zip "https://github.com/facebook/zstd/releases/download/v$ZSTD_VERSION/zstd-v$ZSTD_VERSION-win64.zip"
+	 	unzip zstd.zip 
+		cp -r zstd-v$ZSTD_VERSION-win64/* deps/zstd
+		rm zstd.zip
+		rm -rf zstd-v$ZSTD_VERSION-win64
 	else
 		curl -L "https://github.com/facebook/zstd/releases/download/v$ZSTD_VERSION/zstd-$ZSTD_VERSION.tar.gz" \
 	 	| 	tar  -zxf - -C deps/zstd --strip-components 1
@@ -32,4 +35,4 @@ build_zstd() {
 
 clean_deps
 download_zstd
-build_zstd
+# build_zstd

--- a/etc/install-zstd.sh
+++ b/etc/install-zstd.sh
@@ -6,12 +6,23 @@ clean_deps() {
 	rm -rf deps
 }
 
+download_zstd_windows() {
+	curl -L "https://github.com/facebook/zstd/releases/download/v$ZSTD_VERSION/zstd-$ZSTD_VERSION-win64.zip" \
+	 	| tar  -zxf - -C deps/zstd --strip-components 1
+}
+
 download_zstd() {
 	mkdir -p deps/zstd
 	ZSTD_VERSION=$(node -p "require('./package.json')['mongodb:zstd_version']")
+	is_windows=$(node -p "process.platform === 'win32'")
 
-	curl -L "https://github.com/facebook/zstd/releases/download/v$ZSTD_VERSION/zstd-$ZSTD_VERSION.tar.gz" \
+
+	if [ "$is_windows" == "true" ]; then
+		download_zstd_windows
+	else
+		curl -L "https://github.com/facebook/zstd/releases/download/v$ZSTD_VERSION/zstd-$ZSTD_VERSION.tar.gz" \
 	 	| tar  -zxf - -C deps/zstd --strip-components 1
+	fi
 }
 
 build_zstd() {

--- a/etc/install-zstd.sh
+++ b/etc/install-zstd.sh
@@ -24,6 +24,7 @@ download_zstd() {
 
 	if [ "$is_windows" == "true" ]; then
 		download_windows
+		exit 0 # no need to build windows
 	else
 		# -C -> specifies the output location
 		# --strip-components -> removes one level of directory nesting

--- a/etc/install-zstd.sh
+++ b/etc/install-zstd.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -o xtrace
+set -o errexit
 
 clean_deps() {
 	rm -rf deps

--- a/etc/install-zstd.sh
+++ b/etc/install-zstd.sh
@@ -26,8 +26,11 @@ download_zstd() {
 		download_windows
 		exit 0 # no need to build windows
 	else
-		# -C -> specifies the output location
-		# --strip-components -> removes one level of directory nesting
+		# tar flags
+		#     -C specifies the output location
+		#     --strip-components removes one level of directory nesting
+		# curl flags
+		#     -L follows redirects
 		curl -L "https://github.com/facebook/zstd/releases/download/v$ZSTD_VERSION/zstd-$ZSTD_VERSION.tar.gz" \
 	 	| 	tar -zxf - -C deps/zstd --strip-components 1
 	fi

--- a/etc/install-zstd.sh
+++ b/etc/install-zstd.sh
@@ -6,22 +6,17 @@ clean_deps() {
 	rm -rf deps
 }
 
-download_zstd_windows() {
-	curl -L "https://github.com/facebook/zstd/releases/download/v$ZSTD_VERSION/zstd-$ZSTD_VERSION-win64.zip" \
-	 	| tar  -zxf - -C deps/zstd --strip-components 1
-}
-
 download_zstd() {
 	mkdir -p deps/zstd
 	ZSTD_VERSION=$(node -p "require('./package.json')['mongodb:zstd_version']")
 	is_windows=$(node -p "process.platform === 'win32'")
 
-
 	if [ "$is_windows" == "true" ]; then
-		download_zstd_windows
+		curl -L "https://github.com/facebook/zstd/releases/download/v$ZSTD_VERSION/zstd-$ZSTD_VERSION-win64.zip" \
+	 	| 	unzip - -C deps/zstd 
 	else
 		curl -L "https://github.com/facebook/zstd/releases/download/v$ZSTD_VERSION/zstd-$ZSTD_VERSION.tar.gz" \
-	 	| tar  -zxf - -C deps/zstd --strip-components 1
+	 	| 	tar  -zxf - -C deps/zstd --strip-components 1
 	fi
 }
 


### PR DESCRIPTION
### Description

#### What is changing?

Set errexit in install-zstd.sh.

This causes the install script to fail on windows because the tarball contains symlinks, which cannot be extracted.  The symlink files are not source files, so the build worked without issues before this, but now that errexit is set, we cannot download and extract the zstd source code.

Instead, on windows we now download the prebuilt static library (which does not contain symlinks).

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run format:js && npm run format:rs` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
