### PR TITLE
build(NODE-6604): fix windows builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         shell: bash
 
       - name: install dependencies and compile
-        run: npm install --loglevel verbose
+        run: npm install --ignore-scripts --loglevel verbose && npm run prebuild
         shell: bash
 
       - name: Test ${{ matrix.os }}

--- a/binding.gyp
+++ b/binding.gyp
@@ -23,17 +23,14 @@
           {
             'link_settings': {
               'libraries': [
-                '<(module_root_dir)/deps/zstd/static/zstd_static.lib'
+                '<(module_root_dir)/deps/zstd/out/lib/Debug/zstd_static.lib'
               ]
             },
-            'include_dirs': [
-              '<(module_root_dir)/deps/zstd/include'
-            ],
           },
           { # macos and linux
           'link_settings': {
             'libraries': [
-              '<(module_root_dir)/deps/zstd/build/cmake/lib/libzstd.a',
+              '<(module_root_dir)/deps/zstd/out/lib/libzstd.a',
               ]
             },
           }

--- a/etc/install-zstd.sh
+++ b/etc/install-zstd.sh
@@ -1,49 +1,44 @@
 #!/bin/sh
 set -o xtrace
-set -o errexit
 
 clean_deps() {
 	rm -rf deps
 }
 
-download_windows() {
-	# windows does not support symlinks, so we must download the `win64` build specifically
-	curl -L -o zstd.zip "https://github.com/facebook/zstd/releases/download/v$ZSTD_VERSION/zstd-v$ZSTD_VERSION-win64.zip"
-	# unlike tar, unzip does not have a "strip components" option.  so we unzip the file, copy all the contents to the correct location,
-	# and then delete both the .zip and the unziped content.
-	unzip zstd.zip 
-	cp -r zstd-v$ZSTD_VERSION-win64/* deps/zstd
-	rm zstd.zip
-	rm -rf zstd-v$ZSTD_VERSION-win64
-}
-
 download_zstd() {
 	mkdir -p deps/zstd
 	ZSTD_VERSION=$(node -p "require('./package.json')['mongodb:zstd_version']")
-	is_windows=$(node -p "process.platform === 'win32'")
 
-	if [ "$is_windows" == "true" ]; then
-		download_windows
-		exit 0 # no need to build windows
-	else
-		# tar flags
-		#     -C specifies the output location
-		#     --strip-components removes one level of directory nesting
-		# curl flags
-		#     -L follows redirects
-		curl -L "https://github.com/facebook/zstd/releases/download/v$ZSTD_VERSION/zstd-$ZSTD_VERSION.tar.gz" \
-	 	| 	tar -zxf - -C deps/zstd --strip-components 1
-	fi
+	# only unpack the source and build files needed to compile the project
+	necessary_files="zstd-$ZSTD_VERSION/build zstd-$ZSTD_VERSION/lib zstd-$ZSTD_VERSION/programs"
+	
+	# flags
+	# -L                       follow redirects
+	# -C                       output directory
+	# -                        tar from stdin
+	# --strip-components       ignore the top-level directory when unpacking
+	curl -L "https://github.com/facebook/zstd/releases/download/v$ZSTD_VERSION/zstd-$ZSTD_VERSION.tar.gz" \
+	 	| tar  -zxf - -C deps/zstd --strip-components 1 $necessary_files
 }
 
 build_zstd() {
 	export MACOSX_DEPLOYMENT_TARGET=11
-	cd deps/zstd/build/cmake
+	cd deps/zstd
+
+	mkdir out
+	cd out
 
 	# CMAKE_RC_FLAGS is a workaround for a bug in 1.5.6 that breaks compilation on windows.
 	# The fix is merged but not yet released. see https://github.com/facebook/zstd/issues/3999
-	cmake -DCMAKE_RC_FLAGS="$(pwd)/lib" -DZSTD_MULTITHREAD_SUPPORT=OFF -DZSTD_BUILD_SHARED=OFF -DCMAKE_OSX_ARCHITECTURES='x86_64;arm64' .
-	cmake --build .
+	cmake \
+		-DCMAKE_RC_FLAGS="$(pwd)/lib" \
+		-DZSTD_MULTITHREAD_SUPPORT=OFF \
+		-DZSTD_BUILD_SHARED=OFF \
+		-DCMAKE_OSX_ARCHITECTURES='x86_64;arm64' \
+		-DCMAKE_BUILD_TYPE=Release \
+	    ../build/cmake 
+
+	cmake --build .  --target libzstd_static
 }
 
 clean_deps

--- a/etc/install-zstd.sh
+++ b/etc/install-zstd.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -o xtrace
+set -o errexit
 
 clean_deps() {
 	rm -rf deps


### PR DESCRIPTION
### Description

#### What is changing?

This PR reverts https://github.com/mongodb-js/zstd/pull/51 and goes back to compiling on Windows.  

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run format:js && npm run format:rs` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
