### PR TITLE
docs(NODE-6595): update compatability table for zstd@2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,15 @@ To verify the native `.node` packages, follow the same steps as above using `mon
 
 Only the following version combinations with the [MongoDB Node.js Driver](https://github.com/mongodb/node-mongodb-native) are considered stable.
 
-|               | `@mongodb-js/zstd@1.x` |
-| ------------- | ---------------------- |
-| `mongodb@6.x` | ✓ `^1.1.0`           |
-| `mongodb@5.x` | ✓                      |
-| `mongodb@4.x` | ✓                      |
-| `mongodb@3.x` | N/A                    |
+|                  | `@mongodb-js/zstd@1.x` |
+| ---------------- | ---------------------- |
+| `mongodb@>=6.11` | ✓ `^1.1.0` `^2.0.0`    |
+| `mongodb@<6.11`  | ✓ `^1.1.0`             |
+| `mongodb@5.x`    | ✓                      |
+| `mongodb@4.x`    | ✓                      |
+| `mongodb@3.x`    | N/A                    |
 
-`@mongodb-js/zstd@2.x` is compatible with `mongodb@6.11` and above.  `@mongodb-js/zstd@2.x` will work with
-older versions of mongodb, but will produce peer dependency errors upon installation.
+`@mongodb-js/zstd@2.x` will work with `mongodb@<6.11` but will produce peer dependency errors upon installation.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ To verify the native `.node` packages, follow the same steps as above using `mon
 
 Only the following version combinations with the [MongoDB Node.js Driver](https://github.com/mongodb/node-mongodb-native) are considered stable.
 
-|                  | `@mongodb-js/zstd@1.x` |
-| ---------------- | ---------------------- |
-| `mongodb@>=6.11` | ✓ `^1.1.0` `^2.0.0`    |
-| `mongodb@<6.11`  | ✓ `^1.1.0`             |
-| `mongodb@5.x`    | ✓                      |
-| `mongodb@4.x`    | ✓                      |
-| `mongodb@3.x`    | N/A                    |
+|                  | `@mongodb-js/zstd@1.x` | `@mongodb-js/zstd@2.x` |
+| ---------------- | ---------------------- | ---------------------- |
+| `mongodb@>=6.11` | ✓ `^1.1.0`             | `^2.0.0`               |
+| `mongodb@<6.11`  | ✓ `^1.1.0`             | N/A                    |
+| `mongodb@5.x`    | ✓                      | N/A                    |
+| `mongodb@4.x`    | ✓                      | N/A                    |
+| `mongodb@3.x`    | N/A                    | N/A                    |
 
 `@mongodb-js/zstd@2.x` will work with `mongodb@<6.11` but will produce peer dependency errors upon installation.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @mongodb-js/zstd
 
-[![CI](https://github.com/mongodb-js/zstd/actions/workflows/CI.yml/badge.svg)](https://github.com/mongodb-js/zstd/actions/workflows/CI.yml)
+[![CI](https://github.com/mongodb-js/zstd/actions/workflows/CI.yml/badge.svg)](https://github.com/mongodb-js/zstd/actions/workflows/test.yml)
 
 Zstandard compression library for Node.js
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @mongodb-js/zstd
 
-[![CI](https://github.com/mongodb-js/zstd/actions/workflows/CI.yml/badge.svg)](https://github.com/mongodb-js/zstd/actions/workflows/test.yml)
+[![CI](https://github.com/mongodb-js/zstd/actions/workflows/test.yml/badge.svg)](https://github.com/mongodb-js/zstd/actions/workflows/test.yml)
 
 Zstandard compression library for Node.js
 
@@ -62,6 +62,9 @@ Only the following version combinations with the [MongoDB Node.js Driver](https:
 | `mongodb@5.x` | ✓                      |
 | `mongodb@4.x` | ✓                      |
 | `mongodb@3.x` | N/A                    |
+
+`@mongodb-js/zstd@2.x` is compatible with `mongodb@6.11` and above.  `@mongodb-js/zstd@2.x` will work with
+older versions of mongodb, but will produce peer dependency errors upon installation.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,6 @@ Only the following version combinations with the [MongoDB Node.js Driver](https:
 | `mongodb@4.x`    | ✓                      | N/A                    |
 | `mongodb@3.x`    | N/A                    | N/A                    |
 
-`@mongodb-js/zstd@2.x` will work with `mongodb@<6.11` but will produce peer dependency errors upon installation.
-
 ## API
 
 ```ts


### PR DESCRIPTION
### Description

#### What is changing?

Updates the compatibility table for zstd@2.0.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run format:js && npm run format:rs` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
