### PR TITLE
chore: remove outdated release section from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,12 +108,3 @@ First, install and build the zstd library:
 
 Then:
 `npm test`
-
-## Releasing
-
-CI will automatically publish when it detects a new release after:
-
-```
-npm run release -- --release-as <patch|minor|major>
-git push --follow-tags origin main
-```


### PR DESCRIPTION
### Description

#### What is changing?

- remove readme section about releasing

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

accuracy

### Double check the following

- [ ] Ran `npm run format:js && npm run format:rs` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
