### PR TITLE
docs(NODE-6573): add 1.x deprecation note to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,6 @@ To verify the native `.node` packages, follow the same steps as above using `mon
 
 ## MongoDB Node.js Driver Version Compatibility
 
->[!Note]
-`@mongodb-js/zstd@1.x` is deprecated - please use `@mongodb-js/zstd@2.x` instead.
-
 Only the following version combinations with the [MongoDB Node.js Driver](https://github.com/mongodb/node-mongodb-native) are considered stable.
 
 |                  | `@mongodb-js/zstd@1.x` | `@mongodb-js/zstd@2.x` |
@@ -52,6 +49,9 @@ Only the following version combinations with the [MongoDB Node.js Driver](https:
 | `mongodb@5.x`    | ✓                      | N/A                    |
 | `mongodb@4.x`    | ✓                      | N/A                    |
 | `mongodb@3.x`    | N/A                    | N/A                    |
+
+>[!Note]
+> `@mongodb-js/zstd@1.x` is deprecated - please use `@mongodb-js/zstd@2.x` instead.
 
 #### Prebuild Platforms
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ To verify the native `.node` packages, follow the same steps as above using `mon
 
 ## MongoDB Node.js Driver Version Compatibility
 
+>[!Note]
+`@mongodb-js/zstd@1.x` is deprecated - please use `@mongodb-js/zstd@2.x` instead.
+
 Only the following version combinations with the [MongoDB Node.js Driver](https://github.com/mongodb/node-mongodb-native) are considered stable.
 
 |                  | `@mongodb-js/zstd@1.x` | `@mongodb-js/zstd@2.x` |


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run format:js && npm run format:rs` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
