### PR TITLE
chore: remove vim from musl docker file build

### DIFF
--- a/.github/docker/Dockerfile.musl
+++ b/.github/docker/Dockerfile.musl
@@ -7,7 +7,7 @@ FROM ${PLATFORM}/node:${NODE_VERSION}-alpine AS build
 WORKDIR /zstd
 COPY . .
 
-RUN apk --no-cache add make g++ libc-dev curl bash python3 py3-pip vim cmake
+RUN apk --no-cache add make g++ libc-dev curl bash python3 py3-pip cmake
 RUN npm run install-zstd && npm i
 RUN npm run prebuild
 


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

We don't need vim on every install of our alpine package, only when we're debugging inside the container

### Double check the following

- [ ] Ran `npm run format:js && npm run format:rs` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
