### PR TITLE
fix(NODE-6642): include install script in published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "index.d.ts",
     "lib/index.js",
     "addon/*",
-    "binding.gyp"
+    "binding.gyp",
+    "etc/install-zstd.sh"
   ],
   "dependencies": {
     "node-addon-api": "^8.5.0",


### PR DESCRIPTION
### Description

#### Summary of Changes

Fix \`npm install @mongodb-js/zstd --build-from-source\` failing because the install script referenced a file that was not shipped in the tarball


##### Notes for Reviewers
the install fallback path runs:
- \`npm run clean-install\`
- \`npm run install-zstd\`
- \`bash etc/install-zstd.sh\`

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Package can be build from source upon installation

Fixed an issue where installing `@mongodb-js/zstd` would fail on platforms without a pre-built binary (e.g. new Node.js versions or uncommon architectures). The source-build fallback script `etc/install-zstd.sh` was not included in the published npm package, causing the installation to exit with `bash: etc/install-zstd.sh: No such file or directory`. The script is now shipped with the package so that source builds work correctly.
Thanks @axelonet for submitting the fix!

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Lint is passing (\`npm run check:lint\`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): \`type(NODE-xxxx)[!]: description\`
  - Example: \`feat(NODE-1234)!: rewriting everything in coffeescript\`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket