### PR TITLE
chore(NODE-7566): migrate release workflow to npm Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
 
 name: release
 
@@ -89,6 +88,9 @@ jobs:
 
   publish:
     needs: [release_please, ssdlc, build]
+    permissions:
+      id-token: write
+      contents: read
     environment: release
     runs-on: ubuntu-latest
     steps:
@@ -101,5 +103,3 @@ jobs:
 
       - run: npm publish --provenance --tag latest
         if: ${{ needs.release_please.outputs.release_created }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Description

#### Summary of Changes

Migrate `@mongodb-js/zstd` off `NPM_TOKEN` and onto npm Trusted Publishing (OIDC) per [NODE-7566](https://jira.mongodb.org/browse/NODE-7566).

- Add `id-token: write` to the `publish` job (job-level, least-privilege). The `ssdlc` job already has its own `id-token: write` for AWS OIDC.
- Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`; `npm publish --provenance` obtains the OIDC token automatically.
- Top-level permissions retain only `contents: write` and `pull-requests: write`.

##### Notes for Reviewers

**Before merging:** An npm Trusted Publishing entry must be configured on npmjs.com for the `@mongodb-js/zstd` package, pointing at `release.yml` in this repo. Once verified, `NPM_TOKEN` can be removed from the repo secrets and the package switched to "Require two-factor authentication and disallow tokens."

### Double check the following

- [x] Lint is passing
- [x] Self-review completed
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket