### PR TITLE
fix(NODE-6642): include source build script in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "index.d.ts",
     "lib/index.js",
     "addon/*",
-    "binding.gyp"
+    "binding.gyp",
+    "etc/install-zstd.sh"
   ],
   "dependencies": {
     "node-addon-api": "^8.5.0",


### PR DESCRIPTION
### Description

#### Summary of Changes

`etc/install-zstd.sh` was missing from the `files` array in `package.json`, so it was never included in the published npm package.

When `prebuild-install` cannot find a prebuilt binary (e.g. Node 24 on Windows, or any unsupported platform/architecture combination), the install falls back to `npm run clean-install` → `npm run install-zstd` → `bash etc/install-zstd.sh`. Without the script present, this fails with:

```
bash: etc/install-zstd.sh: No such file or directory
exit code 127
```

This fix adds `etc/install-zstd.sh` to the `files` array. `etc/docker.sh` is intentionally excluded as it is a CI utility not needed for package installation.

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: \`feat(NODE-1234)!: rewriting everything in coffeescript\`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket