### PR TITLE
ci(NODE-7593): switch off macos-13 to macos-26-intel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   host_tests:
     strategy:
       matrix:
-        os: [macos-latest, windows-2022, macos-13]
+        os: [macos-latest, windows-2022, macos-15-intel]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   host_tests:
     strategy:
       matrix:
-        os: [macos-latest, windows-2022, macos-15-intel]
+        os: [macos-latest, windows-2022, macos-26-intel]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   host_tests:
     strategy:
       matrix:
-        os: [macos-latest, windows-2022, macos-13]
+        os: [macos-latest, windows-2022, macos-15-intel]
         node: [20.19.0, 22.x, 24.x]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   host_tests:
     strategy:
       matrix:
-        os: [macos-latest, windows-2022, macos-15-intel]
+        os: [macos-latest, windows-2022, macos-26-intel]
         node: [20.19.0, 22.x, 24.x]
       fail-fast: false
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
### Description

#### Summary of Changes

`macos-13` support was dropped (https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/), so to continue testing Intel Mac, we're switching over to `macos-15-intel`, the closest comparable non-large runner.

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

Current runner is deprecated, all PRs get stuck.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
